### PR TITLE
fix: Duplicated file name in FolderTree returns incorrect slug

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -12,11 +12,11 @@ export function convertTreeData(thisObject: DirectoryTree): TreeData {
 	const children: TreeData[] = [];
 
 	const objectName = thisObject.name;
-	const routerPath = getRouterPath(objectName);
+	const routerPath = getRouterPath(thisObject.path);
 	const newObject: TreeData = {
 		name: objectName.replace(".md", ""),
 		children,
-		id: objectName,
+		id: routerPath ?? objectName,
 		routePath: routerPath,
 	};
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -32,7 +32,7 @@ export function getSearchIndex(): SearchData[] {
 		if (content === null || content === undefined) {
 			break;
 		}
-		const path = getRouterPath(`${title}.md`);
+		const path = getRouterPath(markdownFile);
 		if (path === null) {
 			break;
 		}

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -80,15 +80,14 @@ export function getDirectoryData(): TreeData {
 	return convertTreeData(filteredDirectory);
 }
 
-export function getRouterPath(fileName: string): string | null {
+export function getRouterPath(path: string): string | null {
 	const routerPath = getAllSlugs().find((slug) => {
-		const slugFileName = Transformer.parseFileNameFromPath(toFilePath(slug));
 		return (
-			Transformer.normalizeFileName(slugFileName ?? "") ===
-			Transformer.normalizeFileName(fileName)
+			Transformer.normalizeFileName(slug ?? "") ===
+			Transformer.normalizeFileName(toSlug(path))
 		);
 	});
-	const nameAndExtension = fileName.split(".");
+	const nameAndExtension = path.split(".");
 	return nameAndExtension.length > 1 && routerPath !== undefined
 		? routerPath
 		: null;


### PR DESCRIPTION
I fixed bug that routerPath in TreeView returns invalid value when same filename exists. 
```diff
- Before
- posts/fire/post1 -> /fire/post1
- posts/water/post1-> /fire/post1

+ After
+ posts/fire/post1 -> /fire/post1
+ posts/water/post1-> /water/post1
```