### PR TITLE
fix: duplicated filename resolve system returns error

### DIFF
--- a/kotlin/src/jsMain/kotlin/Cache.kt
+++ b/kotlin/src/jsMain/kotlin/Cache.kt
@@ -65,12 +65,14 @@ fun initCache(
         var pathString = PathString(filePath)
         val plainFileName = pathString.toSlugString(postFolder).toPlainFileName()
         if (nameCache.contains(plainFileName.fileName)) {
-            duplicatedFile += plainFileName.fileName
-            val duplicatedPath = fileNameToPath.remove(plainFileName) ?: error("DuplicatedName:$plainFileName is not found in fileNameToPath")
-            val duplicatedFileName = duplicatedPath.toFileName(postFolder, nameCache)
-            fileNameToPath[duplicatedFileName] = duplicatedPath
-            val duplicatedSlug = fileNameToSlug.remove(plainFileName)!!
-            fileNameToSlug[duplicatedFileName] = duplicatedSlug
+            val duplicatedPath = fileNameToPath.remove(plainFileName)
+            if (duplicatedPath != null) {
+                duplicatedFile += plainFileName.fileName
+                val duplicatedFileName = duplicatedPath.toFileName(postFolder, nameCache)
+                fileNameToPath[duplicatedFileName] = duplicatedPath
+                val duplicatedSlug = fileNameToSlug.remove(plainFileName)!!
+                fileNameToSlug[duplicatedFileName] = duplicatedSlug
+            }
         }
         val fileName = pathString.toFileName(postFolder, nameCache)
         val slug = SlugString(toSlug(filePath))


### PR DESCRIPTION
Fixed an error when a file not in the root path has a duplicate name